### PR TITLE
Logikfehler

### DIFF
--- a/IRTlibAudioInZipNormalizer/Program.cs
+++ b/IRTlibAudioInZipNormalizer/Program.cs
@@ -21,7 +21,7 @@ namespace AudioInZipNormalizer
             {
                 targetDirectory = args[0];
             } 
-            else if (args.Length == 1)
+            if (args.Length > 1)
             {
                 audioMax = float.Parse(args[1], CultureInfo.InvariantCulture);
             }


### PR DESCRIPTION
Wenn args.Length != 0 kann "else if(args.Length == 1)" nie angesteuert werden, da else nur auslöst wenn die erste Bedingung falsch ist und 1!=0
Außerdem willst du ja die Übergabe von zwei Argumenten prüfen, damit sollte die Length ja größer 1 und nicht genau 1 sein.